### PR TITLE
Fix: inconsistent edge thickness of communication channels

### DIFF
--- a/tam-drawio.js
+++ b/tam-drawio.js
@@ -328,9 +328,10 @@ Draw.loadPlugin(function (ui) {
                 new mxPoint(x - lineDirectionCoefficient * circleRadius, y);
             //ui.editor.setStatus(rectMsg + "--" + JSON.stringify(pts) + "--" + cpt.x + "," + cpt.y)
             let pts1 = [...pts.slice(0, p0 + 1), cpt]
+            const strokeWidth = c.getCurrentStrokeWidth();
+            c.setStrokeWidth(strokeWidth);
             drawEdge(pts1);
 
-            const strokeWidth = c.getCurrentStrokeWidth();
             c.setStrokeWidth(strokeWidth * 2);
             c.ellipse(
                 x - circleRadius,


### PR DESCRIPTION
When modeling communication channels and zooming to, say, 200%,
the edges of communication channels have different thickness:

<img width="542" alt="image" src="https://user-images.githubusercontent.com/3993906/151535108-d5e2cbba-139a-4338-9099-57691b762400.png">

Apparently the actual stroke width used to draw the first edge
differs from the getCurrentStrokeWidth() call issued before
drawing the channel which is then used when drawing the second
edge.

This is a quick change addressing the issue.