### PR TITLE
Fix: inconsistent edge thickness of communication channels

### DIFF
--- a/tam-drawio.js
+++ b/tam-drawio.js
@@ -430,9 +430,10 @@ Draw.loadPlugin(function (ui) {
                 new mxPoint(x - lineDirectionCoefficient * circleRadius, y);
             //ui.editor.setStatus(rectMsg + "--" + JSON.stringify(pts) + "--" + cpt.x + "," + cpt.y)
             let pts1 = [...pts.slice(0, p0 + 1), cpt]
+            const strokeWidth = c.getCurrentStrokeWidth();
+            c.setStrokeWidth(strokeWidth);
             drawEdge(pts1);
 
-            const strokeWidth = c.getCurrentStrokeWidth();
             c.setStrokeWidth(strokeWidth * 2);
             c.ellipse(
                 x - circleRadius,


### PR DESCRIPTION
(re-applying this PR as it was overwritten)

When modeling communication channels and zooming to, say, 200%, the edges of communication channels have different thickness.

Apparently the actual stroke width used to draw the first edge differs from the getCurrentStrokeWidth() call issued before drawing the channel which is then used when drawing the second edge.

This is a quick change addressing the issue.