### PR TITLE
Fix double stroke on zoom

### DIFF
--- a/tam-drawio.js
+++ b/tam-drawio.js
@@ -430,7 +430,7 @@ Draw.loadPlugin(function (ui) {
                 new mxPoint(x - lineDirectionCoefficient * circleRadius, y);
             //ui.editor.setStatus(rectMsg + "--" + JSON.stringify(pts) + "--" + cpt.x + "," + cpt.y)
             let pts1 = [...pts.slice(0, p0 + 1), cpt]
-            const strokeWidth = c.getCurrentStrokeWidth();
+            const strokeWidth = c.state.strokeWidth;
             c.setStrokeWidth(strokeWidth);
             drawEdge(pts1);
 


### PR DESCRIPTION
When zooming in the stroke is being doubled and scaled according to the current zoom level.

Instead of `c.getCurrentStrokeWidth()` use `c.state.strokeWidth` which provides the stroke width regardless of the current zoom level.

Fixes https://github.com/ariel-bentu/tam-drawio/issues/19